### PR TITLE
fix a troff formatting error in the manpage.

### DIFF
--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -2221,7 +2221,7 @@ included.
 .IP
 All other characters are output without change and a trailing
 newline is added.
-If unset, the default value, \fB$'\enreal\et%2lR\enuser\et%2lU\ensys\t%2lS'\fP,
+If unset, the default value, \fB$'\enreal\et%2lR\enuser\et%2lU\ensys\et%2lS'\fP,
 is used.  If the value is null, no timing information is displayed.
 .TP
 .B


### PR DESCRIPTION
fixes a trivial troff formatting error in the manpage which results in erroneous display of the default value of TIMEFORMAT with `man ksh`.